### PR TITLE
Fix PIN authorization request

### DIFF
--- a/poauth.rb
+++ b/poauth.rb
@@ -23,10 +23,8 @@ consumer = OAuth::Consumer.new(
   consumer_key,
   consumer_secret,
   {
-    :site => 'http://api.twitter.com/',
-    :request_token_path => '/oauth/request_token',
-    :access_token_path => '/oauth/access_token',
-    :authorize_path => '/oauth/authorize'
+    :site   => 'https://api.twitter.com/',
+    :scheme => :header,
   })
 
 request_token = consumer.get_request_token


### PR DESCRIPTION
When I tried running poauth.rb, I got this error

```
/Library/Ruby/Gems/2.0.0/gems/oauth-0.4.7/lib/oauth/consumer.rb:216:in `token_request': 403 Forbidden (OAuth::Unauthorized)
  from /Library/Ruby/Gems/2.0.0/gems/oauth-0.4.7/lib/oauth/consumer.rb:136:in `get_request_token'
  from poauth.rb:32:in `<main>'
```

After updating it to use the header auth scheme, it worked properly.
